### PR TITLE
chore: docker環境をマイナーチェンジ

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -12,7 +12,7 @@ services:
     volumes:
       - ../db/database:/var/lib/postgresql/data
   djangoapp:
-    image: django/djangoapp:1.0
+    image: django/cyclehood:latest
     build: ./djangoapp
     container_name: "djangoapp_myapp"
     ports:

--- a/.devcontainer/djangoapp/Dockerfile
+++ b/.devcontainer/djangoapp/Dockerfile
@@ -1,5 +1,5 @@
 # M1Macの場合は以下を指定
-FROM python:3.12
+FROM python:3.12-slim
 # それ以外の場合は以下を指定
 # ! 注意:slim版だとpylanceの自動importが効かない
 # FROM python:3.11-slim
@@ -10,28 +10,26 @@ RUN apt-get update -qq \
    tzdata sudo \
    && rm -rf /var/lib/apt/lists/*
 
-# モジュールのインストール
+# 作業ディレクトリの作成
 WORKDIR /tmp/work
-COPY requirements.txt ${PWD}
-# RUN  pip install -upgrade pip
+
+# Pythonモジュールのインストール
+COPY requirements.txt .
 RUN  pip install -r requirements.txt
 
-# 環境変数の定義
+# タイムゾーンの設定
 ENV TZ="Asia/Tokyo"
 
-# 太田 和樹. Docker Desktop for Windows/Macでつくるクリーンな開発環境構築入門(Python版) (pp.498-499). Kindle 版.
-# 一時変数の定義
+# ユーザー・グループ情報
 ARG USERNAME=user1
-ARG PASSWORD=user1
 ARG GROUPNAME=user1
 ARG UID=1000
 ARG GID=1000
 
-# 一般権限のユーザーを追加
+# 一般ユーザー作成
 RUN groupadd -g ${GID} ${GROUPNAME} \
  && useradd -u ${UID} -g ${GID} -G sudo -m -s /bin/bash ${USERNAME} \
- && echo ${USERNAME}:${PASSWORD} | chpasswd \
  && echo "%${USERNAME} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
-# ユーザーの切替
+# 一般ユーザーに切替
 USER ${USERNAME}

--- a/.devcontainer/djangoapp/requirements.txt
+++ b/.devcontainer/djangoapp/requirements.txt
@@ -1,8 +1,8 @@
 django ~= 4.2.0 # 4.2以上4.3未満
-djangorestframework==3.15.2 # 追加
+djangorestframework
 django-environ
 # M1Macはpsycopg2、それ以外はpsycopg2-binary
-psycopg2-binary == 2.9.6
+psycopg2-binary
 pylint-django
 pytest-django
 pytest-xdist


### PR DESCRIPTION
* pythonのdocker-imageに深刻な脆弱性があったのでそれを変更
* ライブラリのver指定をなくし、最新のverをインストールするよう変更